### PR TITLE
Prepare database migration support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <plugin.prettier.goal>write</plugin.prettier.goal>
         <spring-cloud.version>2021.0.3</spring-cloud.version>
         <org.springdoc.version>1.6.9</org.springdoc.version>
+        <liquibase.version>4.19.0</liquibase.version>
     </properties>
     <dependencies>
         <dependency>
@@ -81,6 +82,11 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>${org.springdoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>${liquibase.version}</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,6 @@ keycloak.issuer=http://localhost/keycloak/realms/Gamify-IT
 keycloak.url=http://localhost/keycloak/realms/Gamify-IT
 springdoc.swagger-ui.path=/swagger-ui
 springdoc.swagger-ui.disable-swagger-default-url=true
+
+spring.liquibase.change-log=classpath:db/changelog-root.xml
+

--- a/src/main/resources/db/changelog-root.xml
+++ b/src/main/resources/db/changelog-root.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd
+      http://www.liquibase.org/xml/ns/pro
+      http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
+<includeAll path="db/changelog/"/><!-- Automatically queries all files in this directory in lexical order -->
+</databaseChangeLog>

--- a/src/main/resources/db/changelog-root.xml
+++ b/src/main/resources/db/changelog-root.xml
@@ -7,5 +7,6 @@
       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd
       http://www.liquibase.org/xml/ns/pro
       http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
-<includeAll path="db/changelog/"/><!-- Automatically queries all files in this directory in lexical order -->
+   <!-- Automatically queries all files in this directory in lexical order -->
+   <includeAll path="db/changelog/"/>
 </databaseChangeLog>


### PR DESCRIPTION
In the future, any PR that changes stored data must also adapt the corresponding changelog under `src/main/resources/db/changelog/changelog-<version>.sql`.
New versions should also use a new changelog instead of appending to an old one.
For details on how to keep the changelog up to date, consult the docs.

The initial changelog was not generated as there is no data yet.
Once it is present, it can be added simply by calling

```sh
liquibase generateChangeLog --username $DB_USER --password $DB_PASSWORD --url jdbc:postgresql://localhost:5432/postgres --changeLogFile src/main/resources/db/changelog/changelog-1.0.sql
```

Part of Gamify-IT/issues#439.
Replaces #4.